### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.1](https://github.com/k3ii/revq/compare/0.1.0..0.1.1) - 2024-09-15
+
+### 📚 Documentation
+
+- Specify PAT in README - ([56f4c28](https://github.com/k3ii/revq/commit/56f4c283ae631afd85a470e432d3953b066fcbed))
+- Add gif to readme - ([c0e9d30](https://github.com/k3ii/revq/commit/c0e9d303d01c2c3b6d179fc81baa1beed3e47761))
+
+### ⚙️ Miscellaneous Tasks
+
+- *(ci)* Generate windows pre-built binary - ([09688b8](https://github.com/k3ii/revq/commit/09688b8f6a3d3ff3bb412f4faa9e8585fdbe1e97))
+- Add assets - ([42694d1](https://github.com/k3ii/revq/commit/42694d10dcd0f6f283c8dd780901af3afed05a23))
+
 ## [0.1.0] - 2024-09-12
 
 ### 📇 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1496f8fb1fbf272686b8d37f523dab3e4a7443300055e74cdaa449f3114356"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "arc-swap"
@@ -210,9 +210,9 @@ checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
-version = "1.1.18"
+version = "1.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+checksum = "2d74707dde2ba56f86ae90effb3b43ddd369504387e718014de010cec7959800"
 dependencies = [
  "shlex",
 ]
@@ -1265,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
 
 [[package]]
 name = "openssl-probe"
@@ -1453,7 +1453,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "revq"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap 4.5.17",
@@ -2166,9 +2166,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revq"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Jain Ramchurn"]
 description = "Review and query your pull requests"


### PR DESCRIPTION
## 🤖 New release
* `revq`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/k3ii/revq/compare/0.1.0..0.1.1) - 2024-09-15

### 📚 Documentation

- Specify PAT in README - ([56f4c28](https://github.com/k3ii/revq/commit/56f4c283ae631afd85a470e432d3953b066fcbed))
- Add gif to readme - ([c0e9d30](https://github.com/k3ii/revq/commit/c0e9d303d01c2c3b6d179fc81baa1beed3e47761))

### ⚙️ Miscellaneous Tasks

- *(ci)* Generate windows pre-built binary - ([09688b8](https://github.com/k3ii/revq/commit/09688b8f6a3d3ff3bb412f4faa9e8585fdbe1e97))
- Add assets - ([42694d1](https://github.com/k3ii/revq/commit/42694d10dcd0f6f283c8dd780901af3afed05a23))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).